### PR TITLE
ci: snapshot publish workflow

### DIFF
--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -107,7 +107,6 @@ jobs:
             })
 
   remove-publish-label:
-    needs: create-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -63,9 +63,6 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: ${{ env.JAVA_VERSION }}
-          server-id: ossrh
-          server-username: OSSRH_USERNAME
-          server-password: OSSRH_PASSWORD
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -2,10 +2,7 @@ name: Publish snapshot
 
 on:
   pull_request:
-    branches:
-      - 'main'
-    paths-ignore:
-      - 'README.md'
+    types: [labeled]
 
 env:
   JAVA_VERSION: '17'

--- a/.github/workflows/snapshot.yaml
+++ b/.github/workflows/snapshot.yaml
@@ -1,7 +1,7 @@
-name: Release and publish
+name: Publish snapshot
 
 on:
-  push:
+  pull_request:
     branches:
       - 'main'
     paths-ignore:
@@ -13,9 +13,10 @@ env:
 jobs:
 
   check-version:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'publish-snapshot') }}
     runs-on: ubuntu-latest
     outputs:
-      release-version: ${{ steps.version-step.outputs.version }}
+      snapshot-version: ${{ steps.version-step.outputs.version }}
     steps:
       - uses: actions/checkout@v4
 
@@ -34,10 +35,10 @@ jobs:
           ./gradlew # (load the gradle wrapper, required for the get version step)
           echo "version=$(./gradlew :model:printVersion --console=plain -q)" >> $GITHUB_OUTPUT
 
-      - name: Release version verification
+      - name: Snapshot version verification
         run: |
-          if ! [[ "${{ steps.version-step.outputs.version }}" =~ ^[0-9]+.[0-9]+.[0-9]+$ ]]; then
-            echo "Release interrupted: DDI Lifecycle lib version '${{ steps.version-step.outputs.version }}' is not in correct format X.Y.Z"
+          if ! [[ "${{ steps.version-step.outputs.version }}" =~ ^[0-9]+.[0-9]+.[0-9]+-SNAPSHOT$ ]]; then
+            echo "Snapshot interrupted: DDI Lifecycle lib version '${{ steps.version-step.outputs.version }}' is not in correct format X.Y.Z-SNAPSHOT"
             exit 1
           fi
 
@@ -50,11 +51,11 @@ jobs:
       - name: Tag verification
         run: |
           if [[ "${{ steps.check-tag-exists.outputs.exists }}" == "true" ]]; then
-            echo "Release interrupted: tag '${{ steps.version-step.outputs.version }}' already exists."
+            echo "Snapshot interrupted: tag '${{ steps.version-step.outputs.version }}' already exists."
             exit 1
           fi
 
-  publish:
+  publish-snapshot:
     needs: check-version
     runs-on: ubuntu-latest
     steps:
@@ -68,8 +69,6 @@ jobs:
           server-id: ossrh
           server-username: OSSRH_USERNAME
           server-password: OSSRH_PASSWORD
-          gpg-private-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSWORD
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v3
@@ -80,21 +79,41 @@ jobs:
         env:
           OSSRH_USERNAME: ${{ secrets.OSSRH_USERNAME }}
           OSSRH_PASSWORD: ${{ secrets.OSSRH_TOKEN }}
-          GPG_SIGNING_KEY: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
-          GPG_PASSWORD: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
 
-  create-release:
-    needs: [check-version, publish]
+  write-comment:
+    needs: [check-version, publish-snapshot]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: '👋 Version ${{ needs.check-version.outputs.snapshot-version }} published on maven central repository'
+            })
+
+  create-tag:
+    needs: [check-version, publish-snapshot]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Create tag
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.git.createRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: 'refs/tags/${{ needs.check-version.outputs.snapshot-version }}',
+              sha: context.sha
+            })
+
+  remove-publish-label:
+    needs: create-tag
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Create GitHub release
-        uses: softprops/action-gh-release@v1
+      - uses: actions-ecosystem/action-remove-labels@v1
         with:
-          tag_name: ${{ needs.check-version.outputs.release-version }}
-          target_commitish: ${{ github.head_ref || github.ref }}
-          name: ${{ needs.check-version.outputs.release-version }}
-          files: eno-ws/build/libs/eno-ws.jar
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          labels: 'publish-snapshot'

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,6 +12,7 @@ env:
 
 jobs:
   test:
+    if: ${{ (github.event.pull_request.draft == false) && !contains(github.event.pull_request.labels.*.name, 'publish-snapshot')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -26,7 +26,7 @@ java {
 }
 
 group = "fr.insee.ddi"
-version = "1.0.0-SNAPSHOT"
+version = "1.0.0"
 val nameForArtifactAndJar by extra("ddi-lifecycle")
 
 repositories {

--- a/model/build.gradle.kts
+++ b/model/build.gradle.kts
@@ -123,9 +123,9 @@ publishing {
     repositories {
         maven {
             val isSnapshot: Boolean = version.toString().endsWith("SNAPSHOT")
-            val snapshotRepo2: URI = URI.create("https://s01.oss.sonatype.org/content/repositories/snapshots/")
-            val releaseRepo2: URI = URI.create("https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/")
-            val mavenRepo: URI = if (isSnapshot) snapshotRepo2 else releaseRepo2
+            val snapshotRepo: URI = URI.create("https://oss.sonatype.org/content/repositories/snapshots/")
+            val releaseRepo: URI = URI.create("https://oss.sonatype.org/service/local/staging/deploy/maven2/")
+            val mavenRepo: URI = if (isSnapshot) snapshotRepo else releaseRepo
 
             val commandLineRepoUrl = System.getProperty("repoUrl")
 


### PR DESCRIPTION
Add workflow that allow to publish snapshot version (in maven central snapshot repository) in pull requests, when the label `publish-snapshot` is applied.